### PR TITLE
[RUNTIME] Adds basic UDP integration to the current implementation of runtime

### DIFF
--- a/runtime/testy/Ansible.py
+++ b/runtime/testy/Ansible.py
@@ -10,41 +10,46 @@ sendPort = 1235
 recvPort = 1236
 
 #Custom buffer for handling states. Holds two states, updates one and sends the other.
-class two_buffer(): 
+class TwoBuffer(): 
     def __init__(self):
         self.data = [0, 0]
         self.put_index = 0
         self.get_index = 1
+
     def replace(self, item):
         self.data[self.put_index] = item
-        self.put_index = (self.put_index + 1) % 2
-        self.get_index = (self.get_index + 1) % 2
+        self.put_index = 1 - self.put_index
+        self.get_index = 1 - self.get_index
+
     def get(self):
         return self.data[self.get_index]
 
-sendBuffer = two_buffer()
-recvBuffer = two_buffer()
+sendBuffer = TwoBuffer()
+recvBuffer = TwoBuffer()
 raw_fake_data = [[0]]
 packed_fake_data = [[0]]
 dawn_buffer = [0]
+
 ###Protobuf handlers###
 #Function for handling unpackaging of protobufs from Dawn
 def unpackage(data):
     return data #will be changed when we fully support protos
+
 #Handles packaging and sending state to dawn in the form of protobuf we define
 def package(state, badThingsQueue):
-    s = "TEST"#will be changed when we fully support protos
+    s = "TEST" #will be changed when we fully support protos
     b = bytearray()
     b.extend(map(ord, s))
-    return b
+    return b 
+
 ###Start Ansible Thread Chain###
 def packageData(badThingsQueue, stateQueue, pipe):
-    while(True):
+    while True:
         try:
             rawState = pipe.recv() #Pull state from the pipe
-            if (rawState == SM_COMMANDS.READY):
+            if rawState == SM_COMMANDS.READY:
                 stateQueue.put([SM_COMMANDS.SEND, 1])
-            elif(rawState):
+            elif rawState:
                 packState = package(rawState, badThingsQueue)
                 sendBuffer.replace(pack_state) ##Used list mutation as it's an atomic operation
         except Exception:
@@ -53,46 +58,33 @@ def packageData(badThingsQueue, stateQueue, pipe):
 def udpSender(badThingsQueue, stateQueue, pipe):
     host = socket.gethostname()
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:#DGRAM for UDP sockets
-        while(True): #constantly send the state to Dawn
+        while True: #constantly send the state to Dawn
             try:
                 msg = sendBuffer.get()
-                if(msg != 0): #check if the data inside the buffer has changed
+                if msg != 0: #check if the data inside the buffer has changed
                     s.sendto(msg, (host, sendPort))
             except Exception:
                 badThingsQueue.put(BadThing(sys.exc_info(), None))
+
 def udpReceiver(badThingsQueue, stateQueue, pipe):
     #same thing as the client side from python docs
     host = socket.gethostname()
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) #DGRAM for UDP sockets
     s.bind((host, recvPort))
-    while(True):
+    while True:
         try:
             data = s.recv(2048)
             recvBuffer.replace(data)
         except Exception: 
             badThingsQueue.put(BadThing(sys.exc_info(), None))
+
 def unpackageData(badThingsQueue, stateQueue, pipe):
     ready = False;
-    while(True):
+    while True:
         try:
             ready = pipe.recv()
-            if(ready):
+            if ready:
                 unpackagedData = unpackage(recvBuffer.get())
                 stateQueue.put([SM_COMMANDS.STORE, unpackagedData])
         except Exception:
             badThingsQueue.put(BadThing(sys.exc_info(), None))
-
-
-
-
-        
-
-
-    
-
-
-
-
-  
-
-

--- a/runtime/testy/Ansible.py
+++ b/runtime/testy/Ansible.py
@@ -1,0 +1,98 @@
+import socket
+import threading
+import time
+import fake_dawn
+import random
+import sys
+from runtimeUtil import *
+data = [0] #for testing purposes
+sendPort = 1235
+recvPort = 1236
+
+#Custom buffer for handling states. Holds two states, updates one and sends the other.
+class two_buffer(): 
+    def __init__(self):
+        self.data = [0, 0]
+        self.put_index = 0
+        self.get_index = 1
+    def replace(self, item):
+        self.data[self.put_index] = item
+        self.put_index = (self.put_index + 1) % 2
+        self.get_index = (self.get_index + 1) % 2
+    def get(self):
+        return self.data[self.get_index]
+
+sendBuffer = two_buffer()
+recvBuffer = two_buffer()
+raw_fake_data = [[0]]
+packed_fake_data = [[0]]
+dawn_buffer = [0]
+###Protobuf handlers###
+#Function for handling unpackaging of protobufs from Dawn
+def unpackage(data):
+    return data #will be changed when we fully support protos
+#Handles packaging and sending state to dawn in the form of protobuf we define
+def package(state, badThingsQueue):
+    s = "TEST"#will be changed when we fully support protos
+    b = bytearray()
+    b.extend(map(ord, s))
+    return b
+###Start Ansible Thread Chain###
+def packageData(badThingsQueue, stateQueue, pipe):
+    while(True):
+        try:
+            rawState = pipe.recv() #Pull state from the pipe
+            if (rawState == SM_COMMANDS.READY):
+                stateQueue.put([SM_COMMANDS.SEND, 1])
+            elif(rawState):
+                packState = package(rawState, badThingsQueue)
+                sendBuffer.replace(pack_state) ##Used list mutation as it's an atomic operation
+        except Exception:
+            badThingsQueue.put(BadThing(sys.exc_info(), None))
+
+def udpSender(badThingsQueue, stateQueue, pipe):
+    host = socket.gethostname()
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:#DGRAM for UDP sockets
+        while(True): #constantly send the state to Dawn
+            try:
+                msg = sendBuffer.get()
+                if(msg != 0): #check if the data inside the buffer has changed
+                    s.sendto(msg, (host, sendPort))
+            except Exception:
+                badThingsQueue.put(BadThing(sys.exc_info(), None))
+def udpReceiver(badThingsQueue, stateQueue, pipe):
+    #same thing as the client side from python docs
+    host = socket.gethostname()
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) #DGRAM for UDP sockets
+    s.bind((host, recvPort))
+    while(True):
+        try:
+            data = s.recv(2048)
+            recvBuffer.replace(data)
+        except Exception: 
+            badThingsQueue.put(BadThing(sys.exc_info(), None))
+def unpackageData(badThingsQueue, stateQueue, pipe):
+    ready = False;
+    while(True):
+        try:
+            ready = pipe.recv()
+            if(ready):
+                unpackagedData = unpackage(recvBuffer.get())
+                stateQueue.put([SM_COMMANDS.STORE, unpackagedData])
+        except Exception:
+            badThingsQueue.put(BadThing(sys.exc_info(), None))
+
+
+
+
+        
+
+
+    
+
+
+
+
+  
+
+

--- a/runtime/testy/runtime.py
+++ b/runtime/testy/runtime.py
@@ -7,9 +7,9 @@ import traceback
 
 import stateManager
 import studentAPI
+import Ansible
 
 from runtimeUtil import *
-from Ansible import *
 
 
 # TODO:
@@ -39,10 +39,10 @@ def runtime():
   restartCount = 0
   try:
     spawnProcess(PROCESS_NAMES.STATE_MANAGER, startStateManager)
-    spawnProcess(PROCESS_NAMES.UDP_PACKAGER, packageData)
-    spawnProcess(PROCESS_NAMES.UDP_SENDER, udpSender)
-    spawnProcess(PROCESS_NAMES.UDP_RECEIVER, udpReceiver)
-    spawnProcess(PROCESS_NAMES.UDP_UNPACKAGER, unpackageData)
+    spawnProcess(PROCESS_NAMES.UDP_PACKAGER, Ansible.packageData)
+    spawnProcess(PROCESS_NAMES.UDP_SENDER, Ansible.udpSender)
+    spawnProcess(PROCESS_NAMES.UDP_RECEIVER, Ansible.udpReceiver)
+    spawnProcess(PROCESS_NAMES.UDP_UNPACKAGER, Ansible.unpackageData)
     while True:
       if restartCount >= 5:
         print(RUNTIME_CONFIG.DEBUG_DELIMITER_STRING.value)

--- a/runtime/testy/runtime.py
+++ b/runtime/testy/runtime.py
@@ -9,6 +9,7 @@ import stateManager
 import studentAPI
 
 from runtimeUtil import *
+from Ansible import *
 
 
 # TODO:
@@ -38,6 +39,10 @@ def runtime():
   restartCount = 0
   try:
     spawnProcess(PROCESS_NAMES.STATE_MANAGER, startStateManager)
+    spawnProcess(PROCESS_NAMES.UDP_PACKAGER, packageData)
+    spawnProcess(PROCESS_NAMES.UDP_SENDER, udpSender)
+    spawnProcess(PROCESS_NAMES.UDP_RECEIVER, udpReceiver)
+    spawnProcess(PROCESS_NAMES.UDP_UNPACKAGER, unpackageData)
     while True:
       if restartCount >= 5:
         print(RUNTIME_CONFIG.DEBUG_DELIMITER_STRING.value)

--- a/runtime/testy/runtimeUtil.py
+++ b/runtime/testy/runtimeUtil.py
@@ -14,6 +14,10 @@ class PROCESS_NAMES(Enum):
   STUDENT_CODE        = "studentProcess"
   STATE_MANAGER       = "stateProcess"
   RUNTIME             = "runtime"
+  UDP_PACKAGER        = "udpPackager"
+  UDP_SENDER          = "udpSender"
+  UDP_RECEIVER        = "udpReceiver"
+  UDP_UNPACKAGER       = "udpUnpackager"
 
 @unique
 class SM_COMMANDS(Enum):
@@ -31,6 +35,8 @@ class SM_COMMANDS(Enum):
   HELLO               = ()
   GET_VAL             = ()
   SET_VAL             = ()
+  SEND                = ()
+  RECV                = ()
 
 class RUNTIME_CONFIG(Enum):
   STUDENT_CODE_TIMEOUT = 3

--- a/runtime/testy/runtimeUtil.py
+++ b/runtime/testy/runtimeUtil.py
@@ -17,7 +17,7 @@ class PROCESS_NAMES(Enum):
   UDP_PACKAGER        = "udpPackager"
   UDP_SENDER          = "udpSender"
   UDP_RECEIVER        = "udpReceiver"
-  UDP_UNPACKAGER       = "udpUnpackager"
+  UDP_UNPACKAGER      = "udpUnpackager"
 
 @unique
 class SM_COMMANDS(Enum):

--- a/runtime/testy/stateManager.py
+++ b/runtime/testy/stateManager.py
@@ -16,6 +16,7 @@ class StateManager(object):
     self.input = inputQueue
     # map process names to pipes
     self.processMapping = {PROCESS_NAMES.RUNTIME: runtimePipe}
+
   def initRobotState(self):
     self.state = {
      "incrementer" : 5,

--- a/runtime/testy/stateManager.py
+++ b/runtime/testy/stateManager.py
@@ -16,7 +16,6 @@ class StateManager(object):
     self.input = inputQueue
     # map process names to pipes
     self.processMapping = {PROCESS_NAMES.RUNTIME: runtimePipe}
-
   def initRobotState(self):
     self.state = {
      "incrementer" : 5,
@@ -56,5 +55,9 @@ class StateManager(object):
       elif cmd_type == SM_COMMANDS.HELLO:
         print("HELLO")
       # TODO: Add better error description
+      elif cm_type == SM_COMMANDS.SEND:
+        self.processMapping[PROCESS_NAMES.UDP_PACKAGER].send(state)
+      elif cm_type == SM_COMMANDS.RECEIVE:
+        state["bytes"] = request[1]
       else:
         self.badThingsQueue.put(BadThing(sys.exc_info(), "Unknown process name: %s" % (request,), event = BAD_EVENTS.UNKNOWN_PROCESS, printStackTrace = False))


### PR DESCRIPTION
Creates 4 processes: packager, sender, receiver, unpackager to handle
data and send over it over UDP sockets. These currently don't use
google protos but converts "TEST" into a bytearray and sends over sockets.

To handle async messages, there is a class called two_buffer which just
stores and sends data in two separate indices of a list which are atomic
operations which should be ok for async.

It uses the process factory in runtime.py to generate said processes and
I have added them into the process names enum class. I have also added
additional SM_COMMANDS SEND and RECEIVE. SEND is sent to SM when the
packager is done with packaging one set of data and can accept another.
This should be fixed in the future to constantly send over the state,
potentially using another instance of the two_buffer.
The RECEIVE command just stores whatever we send to state manager into
the state itself which will also need to fixed to handle storing gamepad
data which we expect from Dawn over UDP.
