### PR TITLE
[RUNTIME] Dynamic IP change for Ansible

### DIFF
--- a/runtime/testy/Ansible.py
+++ b/runtime/testy/Ansible.py
@@ -77,6 +77,7 @@ class UDPSendClass(AnsibleHandler):
         self.sendBuffer = TwoBuffer()
         packagerName = THREAD_NAMES.UDP_PACKAGER
         sockSendName = THREAD_NAMES.UDP_SENDER
+        self.dawn_ip = None
         super().__init__(packagerName, UDPSendClass.packageData, sockSendName,
                          UDPSendClass.udpSender, badThingsQueue, stateQueue, pipe)
 
@@ -111,6 +112,8 @@ class UDPSendClass(AnsibleHandler):
                     "UDP packager thread has crashed with error:" + str(e),
                     event = BAD_EVENTS.UDP_SEND_ERROR,
                     printStackTrace = True))
+        stateQueue.put([SM_COMMANDS.SEND_IP, [PROCESS_NAMES.UDP_SEND_PROCESS]])
+        self.dawn_ip = pipe.recv()
         while True:
             try:
                 nextCall = time.time()
@@ -132,14 +135,13 @@ class UDPSendClass(AnsibleHandler):
         The current state that has already been packaged is gotten from the 
         TwoBuffer, and is sent to Dawn via a UDP socket.
         """
-        host = '192.168.128.30' #TODO: Make this not hard coded
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
             while True: 
                 try:
                     nextCall = time.time()
                     msg = self.sendBuffer.get()
-                    if msg != 0 and msg is not None: 
-                        s.sendto(msg, (host, UDPSendClass.SEND_PORT))
+                    if msg != 0 and msg is not None and self.dawn_ip is not None: 
+                        s.sendto(msg, (self.dawn_ip, UDPSendClass.SEND_PORT))
                     nextCall += 1.0/self.socketHZ
                     time.sleep(max(nextCall - time.time(), 0))
                 except Exception as e:
@@ -159,6 +161,7 @@ class UDPRecvClass(AnsibleHandler):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.socket.bind((host, UDPRecvClass.RECV_PORT))
         self.socket.setblocking(False)
+        self.curr_ip = None
         super().__init__(packName, UDPRecvClass.unpackageData, sockRecvName,
                          UDPRecvClass.udpReceiver, badThingsQueue, stateQueue, pipe)
 
@@ -170,9 +173,12 @@ class UDPRecvClass(AnsibleHandler):
         """
         try:
             while True:
-                recv_data = self.socket.recv(2048)
+                recv_data, addr = self.socket.recvfrom(2048)
         except BlockingIOError:
             self.recvBuffer.replace(recv_data)
+            if addr is not self.curr_ip:
+                self.curr_ip = addr
+                self.stateQueue.put([SM_COMMANDS.SET_IP, [addr]])
 
     def unpackageData(self):
         """Unpackages data from proto and sends to stateManager on the SM stateQueue

--- a/runtime/testy/runtime.py
+++ b/runtime/testy/runtime.py
@@ -47,10 +47,10 @@ def runtime(testName=""):
 
   try:
     spawnProcess(PROCESS_NAMES.STATE_MANAGER, startStateManager)
-    spawnProcess(PROCESS_NAMES.UDP_SEND_PROCESS, startUDPSender)
     spawnProcess(PROCESS_NAMES.UDP_RECEIVE_PROCESS, startUDPReceiver)
     spawnProcess(PROCESS_NAMES.HIBIKE, startHibike)
     controlState = "idle"
+    connectionState = False
 
     while True:
       if testMode:
@@ -71,7 +71,17 @@ def runtime(testName=""):
       nonTestModePrint("Starting studentCode attempt: %s" % (restartCount,))
       while True:
         newBadThing = badThingsQueue.get(block=True)
-        if newBadThing.event == BAD_EVENTS.ENTER_TELEOP and controlState != "teleop":
+        if newBadThing.event == BAD_EVENTS.NEW_IP and not connectionState:
+          spawnProcess(PROCESS_NAMES.UDP_SEND_PROCESS, startUDPSender)
+          #spawnProcess(TCP)
+          connectionState = True
+          continue
+        elif newBadThing.event == BAD_EVENTS.DAWN_DISCONNECTED and connectionState:
+          terminate_process(PROCESS_NAMES.UDP_SEND_PROCESS)
+          #terminate_process(tcp)
+          connectionState = False
+          continue
+        elif newBadThing.event == BAD_EVENTS.ENTER_TELEOP and controlState != "teleop":
           spawnProcess(PROCESS_NAMES.STUDENT_CODE, runStudentCode, testName, maxIter)
           controlState = "teleop"
           continue

--- a/runtime/testy/runtimeUtil.py
+++ b/runtime/testy/runtimeUtil.py
@@ -18,6 +18,8 @@ class BAD_EVENTS(Enum):
   ENTER_TELEOP              = "Dawn says enter Teleop" # TODO: BAD_EVENT best way to do this?
   ENTER_AUTO                = "Dawn says enter Auto" # TODO: BAD_EVENT best way to do this?
   ENTER_IDLE                = "Dawn says enter Idle" # TODO: BAD_EVENT best way to do this?
+  NEW_IP                    = "Connected to new instance of Dawn"
+  DAWN_DISCONNECTED         = "Disconnected to Dawn"
 
 restartEvents = [BAD_EVENTS.STUDENT_CODE_ERROR, BAD_EVENTS.STUDENT_CODE_TIMEOUT, BAD_EVENTS.END_EVENT, BAD_EVENTS.EMERGENCY_STOP]
 
@@ -65,6 +67,8 @@ class SM_COMMANDS(Enum):
   GET_TIME            = ()
   EMERGENCY_STOP      = ()
   EMERGENCY_RESTART   = ()
+  SET_IP              = ()
+  SEND_IP             = ()
 
 class RUNTIME_CONFIG(Enum):
   STUDENT_CODE_TIMELIMIT      = 1

--- a/runtime/testy/stateManager.py
+++ b/runtime/testy/stateManager.py
@@ -32,7 +32,9 @@ class StateManager(object):
       SM_COMMANDS.RECV_ANSIBLE: self.recv_ansible,
       SM_COMMANDS.GET_TIME : self.getTimestamp,
       SM_COMMANDS.EMERGENCY_STOP: self.emergencyStop,
-      SM_COMMANDS.EMERGENCY_RESTART: self.emergencyRestart
+      SM_COMMANDS.EMERGENCY_RESTART: self.emergencyRestart,
+      SM_COMMANDS.SET_IP: self.set_ip,
+      SM_COMMANDS.SEND_IP: self.send_ip
     }
     return commandMapping
 
@@ -65,7 +67,8 @@ class StateManager(object):
      "list1" : [[[70, t], ["five", t], [14.3, t]], t],
      "string1" : ["abcde", t],
      "runtime_meta" : [{"studentCode_main_count" : [0, t], "e_stopped" : [False, t]}, t],
-     "hibike" : [{"device_subscribed" : [0, t]}, t]
+     "hibike" : [{"device_subscribed" : [0, t]}, t], 
+     "ip" : [None, t]
     }
 
   def addPipe(self, processName, pipe):
@@ -129,6 +132,12 @@ class StateManager(object):
 
   def recv_ansible(self, new_data):
     self.state.update(new_data)
+
+  def set_ip(self, new_ip):
+    self.state["ip"] = [new_ip, time.time()]
+
+  def send_ip(self, process_name):
+    self.processMapping[process_name].send(self.state["ip"][0])
 
   def getTimestamp(self, keys):
     currDict = self.state


### PR DESCRIPTION
 IP that Ansible sends to changes according to first message sent to us from Dawn.
    
Tested with fake_dawn but requires integration testing with real Dawn as they need to implement new communications protocol.
    
UDP receive waits to receive initial message and then messages runtime to spawn the UDP send process with known ip address.
