### PR TITLE
[HIBIKE] document usage of virtual devices

### DIFF
--- a/hibike/VIRTUAL_DEVICES.md
+++ b/hibike/VIRTUAL_DEVICES.md
@@ -1,0 +1,42 @@
+# Virtual Hibike Devices
+
+Hibike features virtual devices, which attempt to simulate the behavior of real hibike devices for testing purposes.
+
+Virtual devices expose a serial interface similar to the ones exposed by real hibike devices
+
+## Usage
+
+### TL;DR
+
+dependencies:
+ - socat
+ - python3
+ - pyserial for python3
+
+edit line 10 of spawn_virtual_devices.py to configure what devices you want and run it with python3
+
+### socat
+
+In order to expose a serial interface, virtual devices use the command line utility `socat`.
+You must install socat in order to use virtual devices.
+
+Socat essentially generates a pair of connected virtual serial ports. Anything written to one of these ports can be read from the other. This way, the virtual device program can connect to one end of the pair of serial ports, and a program that wishes to communicate with hibike devices, such as `hibike_process.py`, can connect to the other end.
+
+The call we make to spawn a pair of ports is socat is `socat -d -d pty,raw,echo=0 pty,raw,echo=0`.
+
+### virtual_device.py
+
+The python script virtual_device.py simulates a hibike_device.
+It takes in as command line arguments the type of device to emulate and a port to connect to.
+It has an external dependency on pyserial should be run with python3.
+
+If you wish to implement more virtual devices types, or change the behaviour of any of the virtual device types, this is the file to modify.
+
+### spawn_virtual_devices.py
+
+This is a helper script that runs multiple instances the previous two programs, socat and virtual_device.py, to generate multiple virtual hibike devices.
+Furthermore, it collects all the virtual serial ports for communicating with these devices into the file `virtual_devices.txt`, which programs like `hibike_process.py` read to know where virtual_devices are.
+
+It also has an atexit handler that should clean up these child processes, though this may not always happen, for example if `spawn_virtual_devices.py` is killed with SIGKILL.
+
+`spawn_virtual_devices.py` currently hardcodes a list of devices to spawn in line 10. This can be edited to any desired list of devices. The currently supported device types are `LimitSwitch`, `ServoControl`, and `Potentiometer`. Though code for `YogiBear` exists and works, the YogiBear team is currently developing YogiBear firmware with a different set of paramaters, so the use of this virtual device type is not recommended until YogiBear firmware is finalized and the virtual device is updated to match this.

--- a/hibike/spawn_virtual_devices.py
+++ b/hibike/spawn_virtual_devices.py
@@ -7,12 +7,12 @@ import atexit
 import time
 
 popens = []
+devices_to_spawn = ["LimitSwitch", "LimitSwitch", "ServoControl", "Potentiometer"]
 
 def get_virtual_ports():
     socat = subprocess.Popen(shlex.split("socat -d -d pty,raw,echo=0 pty,raw,echo=0"), stderr=subprocess.PIPE)
     popens.append(socat)
     lines = [str(socat.stderr.readline()), str(socat.stderr.readline())]
-    #print(lines)
     p1 = re.search(r'PTY is (/dev/pts/\d+)', lines[0]).group(1)
     p2 = re.search(r'PTY is (/dev/pts/\d+)', lines[1]).group(1)
     return p1, p2
@@ -20,7 +20,7 @@ def get_virtual_ports():
 def spawn_device(device_type):
     p1, p2 = get_virtual_ports()
     fname = os.path.join(os.path.dirname(__file__), "virtual_device.py")
-    device = subprocess.Popen(shlex.split("python3.5 %s -d %s -p %s" % (fname, device_type, p1)))
+    device = subprocess.Popen(shlex.split("python3 %s -d %s -p %s" % (fname, device_type, p1)))
     popens.append(device)
     return p2
 
@@ -32,7 +32,7 @@ def cleanup():
 
 if __name__ == "__main__":
     with open("virtual_devices.txt", "w+") as device_file:
-        devices = [spawn_device("LimitSwitch"), spawn_device("ServoControl")]
+        devices = [spawn_device(device_type) for device_type in devices_to_spawn]
         device_file.write(" ".join(devices))
     while True:
         time.sleep(1)


### PR DESCRIPTION
- add a markdown file documenting the usage of virtual devices
- modify `spawn_virtual_devices.py`, moving the user editable section to the top.
- change the example list of virtual devices in `spawn_virtual_devices.py`
  - demonstrate all 3 supported device types
  - demonstrate support for spawning multiple devices of the same type
- minor bugfix: invoke `python3` instead of `python3.5` , since virtual devices don't require python3.5