### PR TITLE
[DevOps] Set up Travis to build dawn and runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,51 @@
+dist: trusty
+sudo: required
 language: node_js
 node_js:
 - "6"
 os:
-- osx
 - linux
+env:
+  - TEST_DIR=dawn
+  - TEST_DIR=runtime
+before_install:
+- mkdir -p artifacts
+- if [[ $TEST_DIR = dawn ]] && git tag -l --points-at HEAD | grep dawn; then
+    export DEPLOY_ARTIFACTS=1;
+  fi
+- if [[ $TEST_DIR = runtime ]] && git tag -l --points-at HEAD | grep runtime; then
+    export DEPLOY_ARTIFACTS=1;
+  fi
+- mkdir -p build-deps
+- export PATH="$PATH:$PWD/build-deps/bin"
 install:
-- cd dawn
-- make dawn-install
+- pushd $TEST_DIR
+- make install
+- if [[ $DEPLOY_ARTIFACTS = 1 ]]; then
+    make artifacts-install;
+  fi
+- popd
 script:
-- make dawn-test
-- make dawn-lint
+- pushd $TEST_DIR
+- make test
+- make lint
+- if [[ $DEPLOY_ARTIFACTS = 1 ]]; then
+    make artifacts;
+  fi
+- popd
 branches:
   only:
-    - master
+  - master
+  - /^(dawn)\/.*$/
+  - /^(runtime)\/.*$/
+  - /^(test)\/.*$/
+deploy:
+  provider: releases
+  api_key:
+    secure: "Y9p9wvz8ZLX4tM7lygUG1DaqCVOKC8qtpyNL0Nf6kgE6TLpB1fzCnndTg6sz9C6brw2pBriwXe9aHEG3QdV/u3ku4AdQqwT9PqemWJmxJT9ex+Eyk47Sp8do+tkLF44+8IkIlxSlcKfnD99fpAgrZSh3iAotJspyhckDu5R1+UNi1TBIPfBoUOtdKKFGbWNqX9lYyWompBa0Q08ZbIKW10H7HJCWQ9MhwL1Q2RxFRtLANWXLwOUW59gzfLQq07Z8b+PRmMmUiE1jr30OjnDDn+tiJk9kLG/Y5UcxzIpHaq+Wo7a5ncwHcyGaqXCs8q25wDQEsXdq6z6+kFqsi9tQkmMsrM6W9qGO8AVfxGgII6yExf6pweg02dNHMwDNI5JcpEVonP73YwuB7UH2UwUxbxzwsmnGMFYx41EpM0nYua6xHC3SZEqTurBgQMMnELJPMX2lbmFGdZPOJ5lEjnS5UEYazn1VSY00qUrQlU+nnQgbU9GJfSrHhWSJ5ycONGCBbE+dm2/vs9qnKQGXNmKeKhRSw+duNzarx648nNz6kklA9r2st0kVMfLZTMj6nKhksts88Khy1oWhFtdXOqi3daWwGz7H0jG6cvMvxSPBFA2svYy45etaXrXtJtI3kYQPl3ESdeOEWYhjPlsJXb+MVL3DUtDgMFaLRww4z/s0q/E="
+  file: artifacts/*
+  file_glob: true
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: $DEPLOY_ARTIFACTS = 1

--- a/DevOps/frankfurter/scripts/update/create_update.sh
+++ b/DevOps/frankfurter/scripts/update/create_update.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 ##############################################################################################
-# Pulls the newest versions of PieCentral from github and packages hibike and runtime nicely #
-# in a tarball along with the install_update.sh script.                                      #
+# Packages hibike and runtime nicely in a tarball along with the install_update.sh script.   #
 ##############################################################################################
+echo "Don't forget to pull the latest code before running this script!"
+echo "Current commit is: $(git rev-parse HEAD)"
+echo
 
 FRANKFURTER_DIR=$(git rev-parse --show-toplevel)/DevOps/frankfurter
+PROTO_DIR=$(git rev-parse --show-toplevel)/ansible-protos
 BUILD_DIR=$FRANKFURTER_DIR/build
 TMP_DIR=$BUILD_DIR/tmp
 
@@ -19,10 +22,10 @@ fi
 mkdir -p $TMP_DIR
 echo "Done."
 
-git pull origin master
 # Copy hibike and runtime
 cp -R $(git rev-parse --show-toplevel)/hibike $TMP_DIR/hibike
 cp -R $(git rev-parse --show-toplevel)/runtime $TMP_DIR/runtime
+protoc -I=$PROTO_DIR --python_out=$TMP_DIR/runtime/testy $PROTO_DIR/*.proto
 cp $FRANKFURTER_DIR/scripts/update/install_update.sh $TMP_DIR
 
 CURRENT_TIME=$(date +%s%N)

--- a/dawn/Makefile
+++ b/dawn/Makefile
@@ -1,14 +1,28 @@
-dawn-install:
-	npm install
-
 dawn-watch:
 	npm install && npm run-script watch
 
 dawn-start:
 	npm start
 
-dawn-lint:
+install:
+	npm install
+
+artifacts-install:
+	npm install electron-packager
+	sudo dpkg --add-architecture i386
+	sudo apt-get update
+	sudo apt-get install -y wine
+	sudo apt-get install -y p7zip-full
+
+lint:
 	npm run-script lint
 
-dawn-test:
+test:
 	npm test
+
+artifacts:
+	npm run-script build
+	node release.js --platform=win32 --arch=ia32
+	node release.js --platform=darwin --arch=x64
+	node release.js --platform=linux --arch=x64
+	cp ../*.zip ../artifacts

--- a/dawn/package.json
+++ b/dawn/package.json
@@ -18,7 +18,7 @@
       }
     },
     "build": {
-      "command": "cp ../ansible-protos/*.proto ./build && node ./node_modules/webpack/bin/webpack.js -p --config webpack.production.config.js",
+      "command": "mkdir -p ./build && cp ../ansible-protos/*.proto ./build && node ./node_modules/webpack/bin/webpack.js -p --config webpack.production.config.js",
       "env": {
         "NODE_ENV": "production"
       }

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,0 +1,18 @@
+install:
+	cd ../build-deps && wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip
+	cd ../build-deps && unzip protoc-3.2.0-linux-x86_64.zip
+	pip3 install protobuf
+
+artifacts-install:
+	$(nop)
+
+lint:
+	$(nop)
+
+test:
+	cd ../DevOps/frankfurter/scripts/update && ./create_update.sh
+	protoc -I=../ansible-protos --python_out=testy ../ansible-protos/*.proto
+	cd testy && python3 runtime.py --test
+
+artifacts:
+	cp ../DevOps/frankfurter/build/*.tar.gz ../artifacts

--- a/runtime/testy/runtime.py
+++ b/runtime/testy/runtime.py
@@ -261,6 +261,7 @@ def runtimeTest(testNames):
     print("Inspect with 'diff {{test_name}}_output {0}{{test_name}}_output".format(RUNTIME_CONFIG.TEST_OUTPUT_DIR.value))
     for testName in failedTests:
       print("    {0}".format(testName))
+    sys.exit(1)
 
 def testSuccess(testFileName):
   expectedOutput = RUNTIME_CONFIG.TEST_OUTPUT_DIR.value + testFileName


### PR DESCRIPTION
By default, travis will run dawn tests, runtime tests, and package
a runtime update tarball (but not do anything with it).

If a commit is tagged starting with dawn/ or test/dawn/, it will
additionally build Dawn binaries and upload them to GitHub releases.

If a commit is tagged starting with runtime/ or test/runtime, it
will additionally upload the runtime update tarball to GitHub
releases.