### PR TITLE
[DAWN] Fix non-general param handling

### DIFF
--- a/dawn/package.json
+++ b/dawn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Dawn",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Frontend for PIE Robotics System",
   "license": "Apache-2.0",
   "private": true,

--- a/dawn/renderer/reducers/peripherals.js
+++ b/dawn/renderer/reducers/peripherals.js
@@ -7,6 +7,14 @@ const initialPeripheralState = {
   runtimeVersion: '0.0.0',
 };
 
+function getParams(peripheral) {
+  const res = {};
+  peripheral.param_value.forEach((obj) => {
+    res[obj.param] = obj[obj.kind];
+  });
+  return res;
+}
+
 const peripherals = (state = initialPeripheralState, action) => {
   const nextState = Object.assign({}, state);
   const nextPeripherals = nextState.peripheralList;
@@ -15,18 +23,15 @@ const peripherals = (state = initialPeripheralState, action) => {
       const keys = [];
       action.peripherals.forEach((peripheral) => {
         if (peripheral.device_type === PeripheralTypes.BatteryBuzzer) {
-          if (peripheral.param_value[0].param === 'is_unsafe') {
-            nextState.batterySafety = peripheral.param_value[0].bool_value;
-            nextState.batteryLevel = peripheral.param_value[1].float_value;
-          } else {
-            nextState.batteryLevel = peripheral.param_value[0].float_value;
-            nextState.batterySafety = peripheral.param_value[1].bool_value;
+          const batteryParams = getParams(peripheral);
+          if (batteryParams.is_unsafe !== undefined) {
+            nextState.batterySafety = batteryParams.is_unsafe;
+          }
+          if (batteryParams.v_batt !== undefined) {
+            nextState.batteryLevel = batteryParams.v_batt;
           }
         } else if (peripheral.uid === '-1') {
-          const version = {};
-          peripheral.param_value.forEach((obj) => {
-            version[obj.param] = obj[obj.kind];
-          });
+          const version = getParams(peripheral);
           nextState.runtimeVersion = `${version.major}.${version.minor}.${version.patch}`;
         } else {
           keys.push(peripheral.uid);


### PR DESCRIPTION
Dawn would error if the battery buzzer did not report exactly the
two params that were expected from it.