### PR TITLE
[RUNTIME] Change runtimeUtil to have BAD_EVENTS include timestamps mssgs

### DIFF
--- a/runtime/runtimeUtil.py
+++ b/runtime/runtimeUtil.py
@@ -35,6 +35,8 @@ class BAD_EVENTS(Enum):
     ENTER_IDLE                = "Dawn says enter Idle"
     NEW_IP                    = "Connected to new instance of Dawn"
     DAWN_DISCONNECTED         = "Disconnected to Dawn"
+    TIMESTAMP_DOWN             = "Latency test down, down this stack"
+    TIMESTAMP_UP               = "Latency test up, up this stack"
 
 restartEvents = [BAD_EVENTS.STUDENT_CODE_VALUE_ERROR, BAD_EVENTS.STUDENT_CODE_ERROR,
                  BAD_EVENTS.STUDENT_CODE_TIMEOUT, BAD_EVENTS.END_EVENT, BAD_EVENTS.EMERGENCY_STOP]

--- a/runtime/runtimeUtil.py
+++ b/runtime/runtimeUtil.py
@@ -35,8 +35,8 @@ class BAD_EVENTS(Enum):
     ENTER_IDLE                = "Dawn says enter Idle"
     NEW_IP                    = "Connected to new instance of Dawn"
     DAWN_DISCONNECTED         = "Disconnected to Dawn"
-    TIMESTAMP_DOWN             = "Latency test down, down this stack"
-    TIMESTAMP_UP               = "Latency test up, up this stack"
+    TIMESTAMP_DOWN            = "Latency test down this the stack"
+    TIMESTAMP_UP              = "Latency test up this the stack"
 
 restartEvents = [BAD_EVENTS.STUDENT_CODE_VALUE_ERROR, BAD_EVENTS.STUDENT_CODE_ERROR,
                  BAD_EVENTS.STUDENT_CODE_TIMEOUT, BAD_EVENTS.END_EVENT, BAD_EVENTS.EMERGENCY_STOP]


### PR DESCRIPTION
Modified runtimeUtil.py as to include timestamp events - TIMESTAMP_DOWN & TIMESTAMP_UP - and their messages - "Latency test ... - ... this stack".