### PR TITLE
[HIBIKE] Slow down hotplug polling period to 5 seconds

### DIFF
--- a/hibike/hibike_process.py
+++ b/hibike/hibike_process.py
@@ -27,7 +27,7 @@ BATCH_SLEEP_TIME = .04
 IDENTIFY_TIMEOUT = 1
 # Time in seconds to wait between checking for new devices
 # and cleaning up old ones.
-HOTPLUG_POLL_INTERVAL = 1
+HOTPLUG_POLL_INTERVAL = 5
 
 
 def get_working_serial_ports(excludes=()):


### PR DESCRIPTION
It seems as though robots with a lot of devices are having performance issues. This should mitigate them.